### PR TITLE
Rename "kcc" to "vc"

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Process directories
         run: |
           # List of directories to process
-          directories=("kcc" "tbdex")
+          directories=("tbdex" "vc")
 
           # Function to check if a directory is a submodule
           is_submodule() {

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "tbdex"]
 	path = tbdex
 	url = https://github.com/TBD54566975/tbdex.git
-[submodule "kcc"]
-	path = kcc
+[submodule "vc"]
+	path = vc
 	url = https://github.com/TBD54566975/known-customer-credential.git


### PR DESCRIPTION
This PR:
- will rename the `kcc` submodule to `vc` so that the KCC and KBC schemas are hosted at [https://vc.schemas.host](https://vc.schemas.host)